### PR TITLE
init commit

### DIFF
--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -459,6 +459,15 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         let locator = locator ?? currentLocation
         spreads = EPUBSpread.makeSpreads(for: publication, readingProgression: readingProgression, pageCountPerSpread: pageCountPerSpread)
         
+        if let minChapter = self.config.trimmedToc?.first, let index = self.spreads.firstIndex(withHref: minChapter.href) {
+            self.paginationView.minPageNumber = index
+        }
+        
+        if let maxChapter = self.config.trimmedToc?.last, let index = self.spreads.firstIndex(withHref: maxChapter.href) {
+            self.paginationView.maxPageNumber = index
+        }
+        
+        
         let initialIndex: Int = {
             if let href = locator?.href, let foundIndex = spreads.firstIndex(withHref: href) {
                 return foundIndex
@@ -468,14 +477,6 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         }()
         
         paginationView.reloadAtIndex(initialIndex, location: PageLocation(locator), pageCount: spreads.count, readingProgression: readingProgression) {
-            if let minChapter = self.config.trimmedToc?.first, let index = self.spreads.firstIndex(withHref: minChapter.href) {
-                self.paginationView.minPageNumber = index
-            }
-            
-            if let maxChapter = self.config.trimmedToc?.last, let index = self.spreads.firstIndex(withHref: maxChapter.href) {
-                self.paginationView.maxPageNumber = index
-            }
-            
             self.on(.loaded)
         }
     }

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -82,6 +82,8 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
 
         /// Logs the state changes when true.
         public var debugState: Bool
+        
+        public var trimmedToc: [Link]?
 
         public init(
             userSettings: UserSettings = UserSettings(),
@@ -272,7 +274,6 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
 
         editingActions.updateSharedMenuController()
-
         reloadSpreads(at: initialLocation)
     }
     
@@ -467,6 +468,14 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         }()
         
         paginationView.reloadAtIndex(initialIndex, location: PageLocation(locator), pageCount: spreads.count, readingProgression: readingProgression) {
+            if let minChapter = self.config.trimmedToc?.first, let index = self.spreads.firstIndex(withHref: minChapter.href) {
+                self.paginationView.minPageNumber = index
+            }
+            
+            if let maxChapter = self.config.trimmedToc?.last, let index = self.spreads.firstIndex(withHref: maxChapter.href) {
+                self.paginationView.maxPageNumber = index
+            }
+            
             self.on(.loaded)
         }
     }
@@ -858,6 +867,9 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
     
     func paginationView(_ paginationView: PaginationView, pageViewAtIndex index: Int) -> (UIView & PageView)? {
         let spread = spreads[index]
+        if let trimmedToc = config.trimmedToc, trimmedToc.map({ spread.contains(href: $0.href) }).filter({ $0 }).isEmpty {
+            return nil
+        }
         let spreadViewType = (spread.layout == .fixed) ? EPUBFixedSpreadView.self : EPUBReflowableSpreadView.self
         let spreadView = spreadViewType.init(
             publication: publication,
@@ -890,7 +902,11 @@ extension EPUBNavigatorViewController: PaginationViewDelegate {
     }
 
     func paginationView(_ paginationView: PaginationView, positionCountAtIndex index: Int) -> Int {
-        return spreads[index].positionCount(in: publication)
+        let spread = spreads[index]
+        if let trimmedToc = config.trimmedToc, trimmedToc.map({ spread.contains(href: $0.href) }).filter({ $0 }).isEmpty {
+            return 0
+        }
+        return spread.positionCount(in: publication)
     }
 }
 

--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -274,6 +274,7 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         view.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapBackground)))
 
         editingActions.updateSharedMenuController()
+        
         reloadSpreads(at: initialLocation)
     }
     
@@ -466,7 +467,6 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         if let maxChapter = self.config.trimmedToc?.last, let index = self.spreads.firstIndex(withHref: maxChapter.href) {
             self.paginationView.maxPageNumber = index
         }
-        
         
         let initialIndex: Int = {
             if let href = locator?.href, let foundIndex = spreads.firstIndex(withHref: href) {


### PR DESCRIPTION
This PR provides variables for the app to set if we detect an epub asset has a minimum and maximum chapter. We prevent the user to scrolling to places outside of the defined chapters by:

1. Storing a "trimmed" tableOfContents.
2. From that tableOfContents (`[Link]`), converting the first and last of those into indices within our spread.
3. When determining the `contentSize` of the `PaginationView`'s `scrollView`, use these min and max values when provided, and if not just use 0 and `pageCount` respectively. 
4. On all `PaginationViewDelegate` methods implemented by `EPUBNavigationController`, return nil when the locations provided occur outside of our defined chapters.

