### PR TITLE
return to legacy js syntax in reflowable

### DIFF
--- a/r2-navigator-swift/EPUB/Assets/Static/scripts/readium-reflowable.js
+++ b/r2-navigator-swift/EPUB/Assets/Static/scripts/readium-reflowable.js
@@ -4770,7 +4770,9 @@ function appendVirtualColumnIfNeeded() {
   const id = "readium-virtual-page";
   var virtualCol = document.getElementById(id);
   if (isScrollModeEnabled() || getColumnCountPerScreen() != 2) {
-    virtualCol?.remove();
+    if (virtualCol) {
+      virtualCol.remove();
+    }
   } else {
     var documentWidth = document.scrollingElement.scrollWidth;
     var pageWidth = window.innerWidth;


### PR DESCRIPTION
Remove the `?` from line 4773 because iOS < 15 WKWebView js version doesn't support it