### PR TITLE
HEIA-4321: fixed progression of selected text

### DIFF
--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -917,18 +917,21 @@ extension EPUBNavigatorViewController: EPUBSpreadViewDelegate {
 
     func spreadView(_ spreadView: EPUBSpreadView, selectionDidChange text: Locator.Text?, frame: CGRect) {
         guard
-            let locator = currentLocation,
+            var locator = currentLocation,
             let text = text
         else {
             editingActions.selection = nil
             return
         }
-        
+        locator = locator.copy(locations: { locations in
+            if spreadView.isScrollEnabled {
+                locations.progression = frame.origin.y/spreadView.scrollView.contentSize.height
+            }
+        }, text: { $0 = text })
         editingActions.selection = Selection(
-            locator: locator.copy(text: { $0 = text }),
+            locator: locator,
             frame: frame
         )
-        
     }
 
     func spreadViewPagesDidChange(_ spreadView: EPUBSpreadView) {

--- a/r2-navigator-swift/EPUB/EPUBSpreadView.swift
+++ b/r2-navigator-swift/EPUB/EPUBSpreadView.swift
@@ -279,7 +279,6 @@ class EPUBSpreadView: UIView, Loggable, PageView {
         }
 
         focusedResource = spread.links.first(withHREF: href)
-        frame.origin = convertPointToNavigatorSpace(frame.origin)
         delegate?.spreadView(self, selectionDidChange: text, frame: frame)
     }
     


### PR DESCRIPTION
Previously progression for selected text was equal to the top offset progression,  so when we select multiple text without scrolling the view their progression comes out to be same. After this change all the selected text are going to have unique/different progression as now it is offset of the select rect.