### PR TITLE
Fix: App crashing.

### DIFF
--- a/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
+++ b/r2-navigator-swift/EPUB/EPUBNavigatorViewController.swift
@@ -517,7 +517,9 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         
         let link = spreadView.focusedResource ?? spreadView.spread.leading
         let href = link.href
-        let progression = spreadView.progression(in: href)
+        // There are some cases when the progression might come as a negative value, in order to avoid the app to crash we set the value to 0
+        var progression = spreadView.progression(in: href)
+        progression = progression > 0 ? progression : 0
         
         guard let currentLocation = currentLocation,
               let trimmedToc = config.trimmedToc,
@@ -544,7 +546,9 @@ open class EPUBNavigatorViewController: UIViewController, VisualNavigator, Selec
         
         let link = spreadView.focusedResource ?? spreadView.spread.leading
         let href = link.href
-        let progression = spreadView.progression(in: href)
+        // There are some cases when the progression might come as a negative value, in order to avoid the app to crash we set the value to 0
+        var progression = spreadView.progression(in: href)
+        progression = progression > 0 ? progression : 0
         
         // The positions are not always available, for example a Readium WebPub doesn't have any
         // unless a Publication Positions Web Service is provided.


### PR DESCRIPTION
There is an edge case we are not currently handling, basically, there are certain non-compatible EPUBs that have collapsable elements, depending on how the structure of these elements, our getTextWithinFrame function is not working properly, creating weird reactions.

In the meantime, we will create a validation where the progression value will never be negative, we will use 0 instead.

This will avoid the app the crash, let me know what you think about the solution.

Jira ticket:
https://honored.atlassian.net/browse/HSA-1845